### PR TITLE
Update import to match the package name

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,9 +25,9 @@ Make sure to include the CSS and JS files.
 **When using modules**
 
 ```js
-import 'maplibre-gl-inspect/dist/maplibre-gl-inspect.css';
+import '@maplibre/maplibre-gl-inspect/dist/maplibre-gl-inspect.css';
 import maplibregl from 'maplibre-gl';
-import MaplibreInspect from 'maplibre-gl-inspect';
+import MaplibreInspect from '@maplibre/maplibre-gl-inspect';
 
 // Pass an initialized popup to Maplibre GL
 map.addControl(new MaplibreInspect({


### PR DESCRIPTION
The import statements were not working as the package name is @maplibre/maplibre-gl-inspect.

## Launch Checklist

 - [x] Confirm **your changes do not include backports from Mapbox projects** (unless with compliant license) - if you are not sure about this, please ask!
 - [x] Briefly describe the changes in this PR.
 - [ ] Link to related issues.
 - [ ] Include before/after visuals or gifs if this PR includes visual changes.
 - [ ] Document any changes to public APIs.
