### PR TITLE
Improve accessibility of inspect button

### DIFF
--- a/lib/InspectButton.ts
+++ b/lib/InspectButton.ts
@@ -28,7 +28,8 @@ class InspectButton {
     const btn = document.createElement('button');
     btn.className = 'maplibregl-ctrl-icon maplibregl-ctrl-inspect';
     btn.type = 'button';
-    btn.setAttribute('aria-label', 'Inspect');
+    btn.title = 'Toggle Inspect';
+    btn.setAttribute('aria-label', 'Toggle Inspect');
     return btn;
   }
 


### PR DESCRIPTION
* add title and change aria-label to Toggle Inspect

This makes the button control consistent with other default MapLibre buttons like zoom in/out/bearing.

It adds a `title` to the DOM element so it can be hovered, and it changes the wording to "Toggle Inspect" indicating its action.

![CleanShot 2025-01-05 at 17 45 50@2x](https://github.com/user-attachments/assets/d02be7fa-89ea-456b-b12f-8b8fc5aa3bd7)

![CleanShot 2025-01-05 at 17 41 58@2x](https://github.com/user-attachments/assets/d646b6f8-2c50-4a09-b7f1-62d2f8d24bb6)
)

## Launch Checklist

 - [x] Confirm **your changes do not include backports from Mapbox projects** (unless with compliant license) - if you are not sure about this, please ask!
 - [x] Briefly describe the changes in this PR.
 - [x] Include before/after visuals or gifs if this PR includes visual changes.
